### PR TITLE
Add format linking to tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TEST_MAIN_SRC test-main.cc gtest-extra.cc gtest-extra.h util.cc)
 add_library(test-main STATIC ${TEST_MAIN_SRC})
-target_link_libraries(test-main gmock)
+target_link_libraries(test-main format gmock)
 
 # Adds a test.
 # Usage: add_fmt_test(name [CUSTOM_LINK] srcs...)


### PR DESCRIPTION
On my system (Arch Linux) attempt to compile tests ends up in linkage failure. The proposed patch adds proper library to CMakeLists.txt.