### PR TITLE
Adapted to biicode via biicode.conf, ignore.bii and CMakeLists.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ os:
   - osx
 
 before_install:
-  - if [ $TRAVIS_OS_NAME == osx ]; then curl http://www.cmake.org/files/v2.8/cmake-2.8.12.2-Darwin64-universal.tar.gz -o cmake.tar.gz; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then curl http://www.cmake.org/files/v3.0/cmake-3.0.2-Darwin64-universal.tar.gz -o cmake.tar.gz; fi
   - if [ $TRAVIS_OS_NAME == osx ]; then tar xzf cmake.tar.gz; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then export PATH=$PATH:"cmake-2.8.12.2-Darwin64-universal/CMake 2.8-12.app/Contents/bin"; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then export PATH=$PATH:"cmake-3.0.2-Darwin64-universal/CMake.app/Contents/bin"; fi
   - git submodule update --init
 
 env:
@@ -15,9 +15,14 @@ env:
   - BUILD_TYPE=Release
 
 script:
-  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFMT_EXTRA_TESTS=ON .
+  - mkdir build && cd build
+  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFMT_EXTRA_TESTS=ON ..
   - make -j4
   - CTEST_OUTPUT_ON_FAILURE=1 make test
+  - cd .. && rm -rf build/
+  # Building with biicode
+  - ./biicode/support/travis-build.sh
+
 
 after_failure:
   - cat Testing/Temporary/LastTest.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ if (CPP11_FLAG)
   set(CMAKE_REQUIRED_FLAGS ${CPP11_FLAG})
 endif ()
 
+if(BIICODE)
+  include(biicode/cmake/biicode.cmake)
+  return()
+endif(BIICODE)
+
 add_library(format ${FMT_SOURCES})
 if (CMAKE_COMPILER_IS_GNUCXX)
   set_target_properties(format PROPERTIES COMPILE_FLAGS

--- a/biicode.conf
+++ b/biicode.conf
@@ -1,0 +1,16 @@
+# Biicode configuration file
+
+[paths]
+    # Local directories to look for headers (within block)
+    /
+
+[dependencies]
+    # Manual adjust file implicit dependencies, add (+), remove (-), or overwrite (=)
+    CMakeLists.txt + cmake/FindSetEnv.cmake
+    format.h = format.cc
+    format.cc - test/* posix.cc
+    biicode/samples/basic.cpp - test/*
+
+[mains]
+    # Manual adjust of files that define an executable
+    !test/test-main.cc

--- a/biicode/cmake/biicode.cmake
+++ b/biicode/cmake/biicode.cmake
@@ -1,0 +1,18 @@
+# Initializes block variables
+INIT_BIICODE_BLOCK()
+
+# Actually create targets: EXEcutables and libraries.
+ADD_BIICODE_TARGETS()
+
+target_include_directories(${BII_BLOCK_TARGET} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+if (HAVE_OPEN)
+  target_compile_definitions(${BII_BLOCK_TARGET} INTERFACE -DFMT_USE_FILE_DESCRIPTORS=1)
+endif ()
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+  target_compile_options(${BII_BLOCK_TARGET} INTERFACE -Wall -Wextra -Wshadow -pedantic)
+endif ()
+if (CPP11_FLAG AND FMT_EXTRA_TESTS)
+  target_compile_options(${BII_BLOCK_TARGET} INTERFACE ${CPP11_FLAG})
+endif ()

--- a/biicode/samples/basic.cpp
+++ b/biicode/samples/basic.cpp
@@ -1,0 +1,18 @@
+#include "vitaut/cppformat/format.h"
+
+class Date {
+  int year_, month_, day_;
+ public:
+  Date(int year, int month, int day) : year_(year), month_(month), day_(day) {}
+
+  friend std::ostream &operator<<(std::ostream &os, const Date &d) {
+    return os << d.year_ << '-' << d.month_ << '-' << d.day_;
+  }
+};
+
+int main(int argc, char *argv[]){
+	std::string s = fmt::format("The date is {}", Date(2012, 12, 9));
+	fmt::print("Hello, {}!", "world");  // uses Python-like format string syntax
+	fmt::printf("\n%s", s); // uses printf format string syntax
+	return 0;
+}

--- a/biicode/support/travis-build.sh
+++ b/biicode/support/travis-build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ $TRAVIS_OS_NAME == linux ]; then
+    sudo apt-get install libglu1-mesa-dev xorg-dev
+    wget http://www.biicode.com/downloads/latest/ubuntu64
+    mv ubuntu64 bii-ubuntu64.deb
+    (sudo dpkg -i bii-ubuntu64.deb) && sudo apt-get -f install
+    rm bii-ubuntu64.deb
+    wget https://s3.amazonaws.com/biibinaries/thirdparty/cmake-3.0.2-Linux-64.tar.gz
+    tar -xzf cmake-3.0.2-Linux-64.tar.gz
+    sudo cp -fR cmake-3.0.2-Linux-64/* /usr
+    rm -rf cmake-3.0.2-Linux-64
+    rm cmake-3.0.2-Linux-64.tar.gz
+elif [ $TRAVIS_OS_NAME == osx ]; then
+    wget http://www.biicode.com/downloads/latest/macos
+    mv macos macos.pkg
+    sudo installer -pkg macos.pkg -target /
+    rm macos.pkg
+fi
+
+cmake --version
+bii init biicode_project
+mkdir -p ./biicode_project/blocks/vitaut/cppformat
+shopt -s extglob
+mv !(biicode_project|cmake-3.0.2-Darwin64-universal) ./biicode_project/blocks/vitaut/cppformat
+cd biicode_project
+bii cpp:build
+ls bin/*
+./bin/vitaut_cppformat_biicode_samples_basic
+

--- a/ignore.bii
+++ b/ignore.bii
@@ -1,0 +1,3 @@
+doc/*
+breathe/*
+gmock/*


### PR DESCRIPTION
It's a full adaptation of cppformat to biicode. Travis has mixed building with and without biicode at same compilation time to keep your library free of bugs in both building systems.

If you want to publish the repo to biicode directly when you make any modification, add to your `biicode.conf` the parent, e.g.:

    [parent]
         vitaut/cppformat: 0

and execute:

    $ bii publish

to publish the block as DEV in [vitaut/cppformat](http://www.biicode.com/vitaut/cppformat)

I just added a folder named **biicode/** with **cmake/** and **samples/** subfolders to make possible this adaptation and .travis.yml can build an executable with biicode