### PR TITLE
Use explicitly deleted functions to make types non-copyable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,17 @@ endif ()
 #  add_definitions(-DFMT_USE_NOEXCEPT=1)
 #endif ()
 
+#check_cxx_source_compiles("
+#  struct C{
+#    C()=delete;
+#    C(const C&)=delete;
+#    C& operator=(const C&)=delete;
+#  };
+#  int main(){}" FMT_DELETED_FUNCTIONS)
+#if (FMT_DELETED_FUNCTIONS)
+#  add_definitions(-DFMT_USE_DELETED_FUNCTIONS=1)
+#endif ()
+
 # GTest doesn't detect <tuple> with clang.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_definitions(gmock PUBLIC GTEST_USE_OWN_TR1_TUPLE=1)

--- a/format.h
+++ b/format.h
@@ -121,9 +121,16 @@
 
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class
-#define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&); \
-  void operator=(const TypeName&)
+#if FMT_USE_DELETED_FUNCTIONS || FMT_HAS_FEATURE(cxx_deleted_functions) || \
+  (FMT_GCC_VERSION >= 404 && __cplusplus >= 201103L) || _MSC_VER >= 1800
+# define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+    TypeName(const TypeName&) = delete; \
+    TypeName& operator=(const TypeName&) = delete
+#else
+# define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+    TypeName(const TypeName&); \
+    TypeName& operator=(const TypeName&)
+#endif
 
 namespace fmt {
 


### PR DESCRIPTION
Note ```(FMT_GCC_VERSION >= 404 && __cplusplus >= 201103L)``` means ```(FMT_GCC_VERSION >= 407 && __cplusplus >= 201103L)``` actually because of the gcc [bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=1773). CMake checks are suggested.
I'll create another PR after this gets merged. As for nullptr, I think it's acceptable as a [monkey patch](http://en.wikipedia.org/wiki/Monkey_patch). Such things have been done by [libc++](http://llvm.org/viewvc/llvm-project/libcxx/trunk/include/cstddef?view=markup#l87).