### PR TITLE
Detect static assertion support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,13 @@ endif ()
 #  add_definitions(-DFMT_USE_DELETED_FUNCTIONS=1)
 #endif ()
 
+#check_cxx_source_compiles("
+#  static_assert(true, \"\");
+#  int main(){}" FMT_STATIC_ASSERT)
+#if (FMT_STATIC_ASSERT)
+#  add_definitions(-DFMT_USE_STATIC_ASSERT=1)
+#endif ()
+
 # GTest doesn't detect <tuple> with clang.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_definitions(gmock PUBLIC GTEST_USE_OWN_TR1_TUPLE=1)

--- a/format.h
+++ b/format.h
@@ -56,6 +56,9 @@
 // many valid cases.
 #  pragma GCC diagnostic ignored "-Wshadow"
 # endif
+# if __cplusplus >= 201103L || defined __GXX_EXPERIMENTAL_CXX0X__
+#  define FMT_HAS_GXX_CXX11 1
+# endif
 #else
 # define FMT_GCC_EXTENSION
 #endif
@@ -84,12 +87,6 @@
 # define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
 #else
 # define FMT_HAS_CPP_ATTRIBUTE(x) 0
-#endif
-
-#ifdef __GNUC__
-# if __cplusplus >= 201103L || defined __GXX_EXPERIMENTAL_CXX0X__
-#   define FMT_HAS_GXX_CXX11 1
-# endif
 #endif
 
 #ifndef FMT_USE_VARIADIC_TEMPLATES

--- a/format.h
+++ b/format.h
@@ -86,13 +86,19 @@
 # define FMT_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
+#ifdef __GNUC__
+# if __cplusplus >= 201103L || defined __GXX_EXPERIMENTAL_CXX0X__
+#   define FMT_HAS_GXX_CXX11 1
+# endif
+#endif
+
 #ifndef FMT_USE_VARIADIC_TEMPLATES
 // Variadic templates are available in GCC since version 4.4
 // (http://gcc.gnu.org/projects/cxx0x.html) and in Visual C++
 // since version 2013.
 # define FMT_USE_VARIADIC_TEMPLATES \
    (FMT_HAS_FEATURE(cxx_variadic_templates) || \
-       (FMT_GCC_VERSION >= 404 && __cplusplus >= 201103) || _MSC_VER >= 1800)
+       (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1800)
 #endif
 
 #ifndef FMT_USE_RVALUE_REFERENCES
@@ -103,7 +109,7 @@
 # else
 #  define FMT_USE_RVALUE_REFERENCES \
     (FMT_HAS_FEATURE(cxx_rvalue_references) || \
-        (FMT_GCC_VERSION >= 403 && __cplusplus >= 201103) || _MSC_VER >= 1600)
+        (FMT_GCC_VERSION >= 403 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1600)
 # endif
 #endif
 
@@ -113,7 +119,7 @@
 
 // Define FMT_USE_NOEXCEPT to make C++ Format use noexcept (C++11 feature).
 #if FMT_USE_NOEXCEPT || FMT_HAS_FEATURE(cxx_noexcept) || \
-  (FMT_GCC_VERSION >= 408 && __cplusplus >= 201103)
+  (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11)
 # define FMT_NOEXCEPT noexcept
 #else
 # define FMT_NOEXCEPT throw()
@@ -122,7 +128,7 @@
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class
 #if FMT_USE_DELETED_FUNCTIONS || FMT_HAS_FEATURE(cxx_deleted_functions) || \
-  (FMT_GCC_VERSION >= 404 && __cplusplus >= 201103L) || _MSC_VER >= 1800
+  (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1800
 # define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
     TypeName(const TypeName&) = delete; \
     TypeName& operator=(const TypeName&) = delete

--- a/posix.h
+++ b/posix.h
@@ -68,7 +68,8 @@
 # define FMT_UNUSED
 #endif
 
-#if FMT_USE_STATIC_ASSERT
+#if FMT_USE_STATIC_ASSERT || FMT_HAS_CPP_ATTRIBUTE(cxx_static_assert) || \
+  (FMT_GCC_VERSION >= 403 && __cplusplus >= 201103) ||  _MSC_VER >= 1600 
 # define FMT_STATIC_ASSERT(cond, message) static_assert(cond, message)
 #else
 # define FMT_CONCAT_(a, b) FMT_CONCAT(a, b)

--- a/posix.h
+++ b/posix.h
@@ -69,7 +69,7 @@
 #endif
 
 #if FMT_USE_STATIC_ASSERT || FMT_HAS_CPP_ATTRIBUTE(cxx_static_assert) || \
-  (FMT_GCC_VERSION >= 403 && __cplusplus >= 201103) ||  _MSC_VER >= 1600 
+  (FMT_GCC_VERSION >= 403 && FMT_HAS_GXX_CXX11) ||  _MSC_VER >= 1600 
 # define FMT_STATIC_ASSERT(cond, message) static_assert(cond, message)
 #else
 # define FMT_CONCAT_(a, b) FMT_CONCAT(a, b)


### PR DESCRIPTION
In addition, we use [__GXX_EXPERIMENTAL_CXX0X__](http://stackoverflow.com/questions/2958398/gnu-c-how-to-check-when-std-c0x-is-in-effect#answer-2958415) for better C++11 detection now