### PR TITLE
Silence warnings on Windows

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -488,10 +488,10 @@ FMT_FUNC int fmt::internal::UTF16ToUTF8::convert(fmt::WStringRef s) {
 }
 
 FMT_FUNC void fmt::WindowsError::init(
-    int error_code, StringRef format_str, ArgList args) {
-  error_code_ = error_code;
+    int err_code, StringRef format_str, ArgList args) {
+  error_code_ = err_code;
   MemoryWriter w;
-  internal::format_windows_error(w, error_code, format(format_str, args));
+  internal::format_windows_error(w, err_code, format(format_str, args));
   std::runtime_error &base = *this;
   base = std::runtime_error(w.str());
 }

--- a/posix.cc
+++ b/posix.cc
@@ -134,13 +134,13 @@ void fmt::File::close() {
 
 fmt::LongLong fmt::File::size() const {
 #ifdef _WIN32
-  LARGE_INTEGER size = {};
+  LARGE_INTEGER filesize = {};
   HANDLE handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd_));
-  if (!FMT_SYSTEM(GetFileSizeEx(handle, &size)))
+  if (!FMT_SYSTEM(GetFileSizeEx(handle, &filesize)))
     throw WindowsError(GetLastError(), "cannot get file size");
-  FMT_STATIC_ASSERT(sizeof(fmt::LongLong) >= sizeof(size.QuadPart),
+  FMT_STATIC_ASSERT(sizeof(fmt::LongLong) >= sizeof(filesize.QuadPart),
       "return type of File::size is not large enough");
-  return size.QuadPart;
+  return filesize.QuadPart;
 #else
   typedef struct stat Stat;
   Stat file_stat = Stat();
@@ -228,7 +228,7 @@ fmt::BufferedFile fmt::File::fdopen(const char *mode) {
 
 long fmt::getpagesize() {
 #ifdef _WIN32
-  SYSTEM_INFO si = {};
+  SYSTEM_INFO si;
   GetSystemInfo(&si);
   return si.dwPageSize;
 #else

--- a/test/util-test.cc
+++ b/test/util-test.cc
@@ -699,9 +699,8 @@ void test_count_digits() {
 }
 
 TEST(UtilTest, StringRef) {
-  char space[100];
-  std::strcpy(space, "some string");
-  EXPECT_EQ(sizeof("some string") - 1, StringRef(space).size());
+  char space[100] = "some string";
+  EXPECT_EQ(std::strlen(space), StringRef(space).size());
 }
 
 TEST(UtilTest, CountDigits) {


### PR DESCRIPTION
Silences more warnings when building on Windows
 * Rename  error_code to err_code as @vitaut's suggestion