### PR TITLE
Improve behaviors when disabling exceptions

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -451,6 +451,7 @@ const uint64_t fmt::internal::BasicData<T>::POWERS_OF_10_64[] = {
 };
 
 FMT_FUNC void fmt::internal::report_unknown_type(char code, const char *type) {
+  (void)type;
   if (std::isprint(static_cast<unsigned char>(code))) {
     FMT_THROW(fmt::FormatError(
         fmt::format("unknown format code '{}' for {}", code, type)));
@@ -725,6 +726,7 @@ void fmt::internal::PrintfFormatter<Char>::parse_flags(
 template <typename Char>
 Arg fmt::internal::PrintfFormatter<Char>::get_arg(
     const Char *s, unsigned arg_index) {
+  (void)s;
   const char *error = 0;
   Arg arg = arg_index == UINT_MAX ?
     next_arg(error) : FormatterBase::get_arg(arg_index - 1, error);

--- a/format.cc
+++ b/format.cc
@@ -67,7 +67,7 @@ using fmt::internal::Arg;
 # if FMT_EXCEPTIONS
 #  define FMT_THROW(x) throw x
 # else
-#  ifdef DEBUG
+#  ifndef NDEBUG
 #   define FMT_THROW(x) assert(false && #x)
 #  elif defined _MSC_VER
 #   define FMT_THROW(x) __assume(0)
@@ -84,6 +84,8 @@ using fmt::internal::Arg;
 #  define FMT_NORETURN __attribute__((__noreturn__))
 # elif defined _MSC_VER
 #  define FMT_NORETURN __declspec(noreturn)
+# else
+#  define FMT_NORETURN
 # endif
 #endif
 


### PR DESCRIPTION
Functions which unconditionally throw exceptions should never return, with or without exception enabled

Tested compiler: AppleClang 6.1, brew g++-4.9 on OS X 10.10.2