### PR TITLE
Fix CMake CPP11_FLAG not being added to compile flags when FMT_EXTRA_TESTS is OFF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,10 @@ if (CMAKE_COMPILER_IS_GNUCXX)
   set_target_properties(format PROPERTIES COMPILE_FLAGS
     "-Wall -Wextra -Wshadow -pedantic")
 endif ()
-if (CPP11_FLAG AND FMT_EXTRA_TESTS)
+if (CPP11_FLAG)
   set_target_properties(format PROPERTIES COMPILE_FLAGS ${CPP11_FLAG})
+endif ()
+if (FMT_EXTRA_TESTS)
   # Test compilation with default flags.
   file(GLOB src RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/*.cc test/*.h)
   add_library(testformat STATIC ${FMT_SOURCE_FILES} ${src})


### PR DESCRIPTION
I might have misunderstood something, but it seems wrong that you have to enable the extra tests for C++11 support.