### PR TITLE
Fix build under g++-4.9, SunOS 5.11 i386 i86pc Solaris

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -226,14 +226,14 @@ void format_error_code(fmt::Writer &out, int error_code,
   // bad_alloc.
   out.clear();
   static const char SEP[] = ": ";
-  static const char ERR[] = "error ";
+  static const char _ERR[] = "error ";
   fmt::internal::IntTraits<int>::MainType ec_value = error_code;
-  // Subtract 2 to account for terminating null characters in SEP and ERR.
+  // Subtract 2 to account for terminating null characters in SEP and _ERR.
   std::size_t error_code_size =
-      sizeof(SEP) + sizeof(ERR) + fmt::internal::count_digits(ec_value) - 2;
+      sizeof(SEP) + sizeof(_ERR) + fmt::internal::count_digits(ec_value) - 2;
   if (message.size() <= fmt::internal::INLINE_BUFFER_SIZE - error_code_size)
     out << message << SEP;
-  out << ERR << error_code;
+  out << _ERR << error_code;
   assert(out.size() <= fmt::internal::INLINE_BUFFER_SIZE);
 }
 


### PR DESCRIPTION
* thanks @VolodymyrLavrenchuk for pointing this out.

Fixes a [build error on SunOS 5.11](http://pastebin.com/JkxfgLZD) caused through a duplicated variable name (probably in system headers).
