### PR TITLE
Support named arguments

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -72,6 +72,10 @@ Write API
 Utilities
 =========
 
+.. doxygenfunction:: fmt::arg(StringRef, const T&)
+
+.. doxygendefine:: FMT_CAPTURE
+
 .. doxygendefine:: FMT_VARIADIC
 
 .. doxygenclass:: fmt::ArgList

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -15,13 +15,15 @@ literal text, it can be escaped by doubling: ``{{`` and ``}}``.
 The grammar for a replacement field is as follows:
 
 .. productionlist:: sf
-   replacement_field: "{" [`arg_index`] [":" `format_spec`] "}"
+   replacement_field: "{" [`arg_field`] [":" `format_spec`] "}"
+   arg_field: `arg_index` | `arg_name`
    arg_index: `integer`
+   arg_name: \^[a-zA-Z_][a-zA-Z0-9_]*$\
 
-In less formal terms, the replacement field can start with an *arg_index*
+In less formal terms, the replacement field can start with an *arg_field*
 that specifies the argument whose value is to be formatted and inserted into
 the output instead of the replacement field.
-The *arg_index* is optionally followed by a *format_spec*, which is preceded
+The *arg_field* is optionally followed by a *format_spec*, which is preceded
 by a colon ``':'``.  These specify a non-default format for the replacement value.
 
 See also the :ref:`formatspec` section.
@@ -73,8 +75,8 @@ The general form of a *standard format specifier* is:
    fill: <a character other than '{' or '}'>
    align: "<" | ">" | "=" | "^"
    sign: "+" | "-" | " "
-   width: `integer` | "{" `arg_index` "}"
-   precision: `integer` | "{" `arg_index` "}"
+   width: `integer` | "{" `arg_field` "}"
+   precision: `integer` | "{" `arg_field` "}"
    type: `int_type` | "c" | "e" | "E" | "f" | "F" | "g" | "G" | "p" | "s"
    int_type: "b" | "B" | "d" | "o" | "x" | "X"
 

--- a/format.cc
+++ b/format.cc
@@ -266,9 +266,8 @@ int parse_nonnegative_int(const Char *&s) {
 }
 
 template <typename Char>
-inline bool is_name_start(Char c)
-{
-    return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || '_' == c;
+inline bool is_name_start(Char c) {
+  return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || '_' == c;
 }
 
 inline void require_numeric_argument(const Arg &arg, char spec) {
@@ -746,7 +745,7 @@ inline Arg fmt::internal::FormatterBase::get_arg(
   assert(map);
   const unsigned* index = map->find(arg_name);
   if (index)
-      return get_arg(*index, error);
+    return get_arg(*index, error);
   error = "argument not found";
   return Arg();
 }

--- a/format.cc
+++ b/format.cc
@@ -585,6 +585,49 @@ FMT_FUNC void fmt::internal::format_windows_error(
 }
 #endif
 
+template <typename Char>
+void fmt::ArgList::Map<Char>::init(const ArgList &args) {
+  if (!map_.empty())
+    return;
+  const internal::NamedArg<Char>* named_arg;
+  bool use_values = args.type(MAX_PACKED_ARGS - 1) == internal::Arg::NONE;
+  if (use_values) {
+    for (unsigned i = 0;/*nothing*/; ++i) {
+      internal::Arg::Type arg_type = args.type(i);
+      switch (arg_type) {
+      case internal::Arg::NONE:
+        return;
+      case internal::Arg::NAMED_ARG:
+        named_arg = static_cast<const internal::NamedArg<Char>*>(args.values_[i].pointer);
+        map_.insert(Pair(named_arg->name, *named_arg));
+        break;
+      default:
+        /*nothing*/;
+      }
+    }
+    return;
+  }
+  for (unsigned i = 0; i != MAX_PACKED_ARGS; ++i) {
+    internal::Arg::Type arg_type = args.type(i);
+    if (arg_type == internal::Arg::NAMED_ARG) {
+      named_arg = static_cast<const internal::NamedArg<Char>*>(args.args_[i].pointer);
+      map_.insert(Pair(named_arg->name, *named_arg));
+    }
+  }
+  for (unsigned i = MAX_PACKED_ARGS;/*nothing*/; ++i) {
+    switch (args.args_[i].type) {
+    case internal::Arg::NONE:
+      return;
+    case internal::Arg::NAMED_ARG:
+      named_arg = static_cast<const internal::NamedArg<Char>*>(args.args_[i].pointer);
+      map_.insert(Pair(named_arg->name, *named_arg));
+      break;
+    default:
+      /*nothing*/;
+    }
+  }
+}
+
 // An argument formatter.
 template <typename Char>
 class fmt::internal::ArgFormatter :
@@ -736,6 +779,8 @@ FMT_FUNC Arg fmt::internal::FormatterBase::do_get_arg(
     break;
   case Arg::NAMED_ARG:
     arg = *static_cast<const internal::Arg*>(arg.pointer);
+  default:
+    /*nothing*/;
   }
   return arg;
 }

--- a/format.h
+++ b/format.h
@@ -164,10 +164,12 @@ inline uint32_t clzll(uint64_t x) {
 // This should be used in the private: declarations for a class
 #if FMT_USE_DELETED_FUNCTIONS || FMT_HAS_FEATURE(cxx_deleted_functions) || \
   (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1800
+# define FMT_DELETED_OR_UNDEFINED  = delete
 # define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
     TypeName(const TypeName&) = delete; \
     TypeName& operator=(const TypeName&) = delete
 #else
+# define FMT_DELETED_OR_UNDEFINED
 # define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
     TypeName(const TypeName&); \
     TypeName& operator=(const TypeName&)
@@ -968,11 +970,9 @@ class MakeValue : public Arg {
     return IsConvertibleToInt<T>::value ? Arg::INT : Arg::CUSTOM;
   }
 
-  template <typename Char_>
-  MakeValue(const NamedArg<Char_> &value) { pointer = &value; }
+  MakeValue(const NamedArg<Char> &value) { pointer = &value; }
 
-  template <typename Char_>
-  static uint64_t type(const NamedArg<Char_> &) { return Arg::NAMED_ARG; }
+  static uint64_t type(const NamedArg<Char> &) { return Arg::NAMED_ARG; }
 };
 
 template <typename Char>
@@ -2745,6 +2745,12 @@ template <typename T>
 inline internal::NamedArg<wchar_t> arg(WStringRef name, const T &arg) {
   return internal::NamedArg<wchar_t>(name, arg);
 }
+
+template <typename Char>
+void arg(StringRef name, const internal::NamedArg<Char>&) FMT_DELETED_OR_UNDEFINED;
+
+template <typename Char>
+void arg(WStringRef name, const internal::NamedArg<Char>&) FMT_DELETED_OR_UNDEFINED;
 }
 
 #if FMT_GCC_VERSION

--- a/format.h
+++ b/format.h
@@ -2940,6 +2940,8 @@ inline internal::NamedArg<wchar_t, T> arg(WStringRef name, const T &arg) {
 
 #define FMT_CAPTURE_ARG_(id, index) ::fmt::arg(#id, id)
 
+#define FMT_CAPTURE_ARG_W_(id, index) ::fmt::arg(L#id, id)
+
 /**
   \rst
   Convenient macro to capture the arguments' names and values into several
@@ -2955,6 +2957,8 @@ inline internal::NamedArg<wchar_t, T> arg(WStringRef name, const T &arg) {
   \endrst
  */
 #define FMT_CAPTURE(...) FMT_FOR_EACH(FMT_CAPTURE_ARG_, __VA_ARGS__)
+
+#define FMT_CAPTURE_W(...) FMT_FOR_EACH(FMT_CAPTURE_ARG_W_, __VA_ARGS__)
 
 namespace fmt {
 FMT_VARIADIC(std::string, format, StringRef)

--- a/format.h
+++ b/format.h
@@ -2940,7 +2940,7 @@ inline internal::NamedArg<wchar_t, T> arg(WStringRef name, const T &arg) {
 
 #define FMT_CAPTURE_ARG_(id, index) ::fmt::arg(#id, id)
 
-#define FMT_CAPTURE_ARG_W_(id, index) ::fmt::arg(L#id, id)
+#define FMT_CAPTURE_ARG_W_(id, index) ::fmt::arg(L###id, id)
 
 /**
   \rst

--- a/format.h
+++ b/format.h
@@ -773,6 +773,11 @@ struct NamedArg {
   T const& arg;
 
   NamedArg(BasicStringRef<Char> name, T const& arg) : name(name), arg(arg) {}
+
+private:
+
+  // Suppress MSVC warning : assignment operator could not be generated
+  NamedArg& operator=(const NamedArg&);
 };
 
 // A formatting argument. It is a POD type to allow storage in
@@ -1559,7 +1564,7 @@ struct ArgArray {
 };
 
 template <typename NameIndexPair, typename T>
-inline void add_named_arg(NameIndexPair* map, T const&, unsigned) {}
+inline void add_named_arg(NameIndexPair*, const T &, unsigned) {}
 
 template <typename NameIndexPair, typename Char, typename T>
 inline void add_named_arg(NameIndexPair*& map, const NamedArg<Char, T> &namedArg, unsigned n) {

--- a/format.h
+++ b/format.h
@@ -1176,53 +1176,16 @@ struct fmt::ArgList::Map {
   typedef std::map<fmt::BasicStringRef<Char>, internal::Arg> MapType;
   typedef typename MapType::value_type Pair;
 
-  void init(const ArgList &args) {
-    if (!map_.empty())
-      return;
-    bool use_values = args.type(MAX_PACKED_ARGS - 1) == internal::Arg::NONE;
-    if (use_values) {
-      add_packed(args, args.values_);
-      return;
-    }
-    add_packed(args, args.args_);
-    const internal::NamedArg<Char>* named_arg;
-    for (unsigned i = MAX_PACKED_ARGS; ; ++i) {
-      switch (args.args_[i].type) {
-      case internal::Arg::NONE:
-        return;
-      case internal::Arg::NAMED_ARG:
-        named_arg = static_cast<const internal::NamedArg<Char>*>(args.args_[i].pointer);
-        map_.insert(Pair(named_arg->name, *named_arg));
-        break;
-      }
-    }
-  }
+  void init(const ArgList &args);
 
-  const internal::Arg* find(const fmt::BasicStringRef<Char> &name) const
-  {
-      typename MapType::const_iterator it = map_.find(name);
-      if (it != map_.end())
-          return &it->second;
-      return 0;
+  const internal::Arg* find(const fmt::BasicStringRef<Char> &name) const {
+    typename MapType::const_iterator it = map_.find(name);
+    if (it != map_.end())
+      return &it->second;
+    return 0;
   }
 
 private:
-
-  template <typename T>
-  void add_packed(const ArgList &args, const T* data) {
-    const internal::NamedArg<Char>* named_arg;
-    for (unsigned i = 0; i != MAX_PACKED_ARGS; ++i) {
-      internal::Arg::Type arg_type = args.type(i);
-      switch (arg_type) {
-      case internal::Arg::NONE:
-        return;
-      case internal::Arg::NAMED_ARG:
-        named_arg = static_cast<const internal::NamedArg<Char>*>(data[i].pointer);
-        map_.insert(Pair(named_arg->name, *named_arg));
-        break;
-      }
-    }
-  }
 
   MapType map_;
 };

--- a/format.h
+++ b/format.h
@@ -970,9 +970,12 @@ class MakeValue : public Arg {
     return IsConvertibleToInt<T>::value ? Arg::INT : Arg::CUSTOM;
   }
 
-  MakeValue(const NamedArg<Char> &value) { pointer = &value; }
+  // Additional template param `Char_` is needed here because make_type always uses MakeValue<char>.
+  template <typename Char_>
+  MakeValue(const NamedArg<Char_> &value) { pointer = &value; }
 
-  static uint64_t type(const NamedArg<Char> &) { return Arg::NAMED_ARG; }
+  template <typename Char_>
+  static uint64_t type(const NamedArg<Char_> &) { return Arg::NAMED_ARG; }
 };
 
 template <typename Char>

--- a/format.h
+++ b/format.h
@@ -280,7 +280,7 @@ class BasicStringRef {
     return lhs.data_ != rhs.data_;
   }
   friend bool operator<(BasicStringRef lhs, BasicStringRef rhs) {
-      return std::lexicographical_compare(lhs.data_, lhs.data_ + lhs.size_, rhs.data_, rhs.data_ + rhs.size_);
+    return std::lexicographical_compare(lhs.data_, lhs.data_ + lhs.size_, rhs.data_, rhs.data_ + rhs.size_);
   }
 };
 
@@ -1563,7 +1563,7 @@ inline void add_named_arg(NameIndexPair* map, T const&, unsigned) {}
 
 template <typename NameIndexPair, typename Char, typename T>
 inline void add_named_arg(NameIndexPair*& map, const NamedArg<Char, T> &namedArg, unsigned n) {
-    *map++ = NameIndexPair(namedArg.name, n);
+  *map++ = NameIndexPair(namedArg.name, n);
 }
 
 #if FMT_USE_VARIADIC_TEMPLATES

--- a/posix.h
+++ b/posix.h
@@ -197,8 +197,8 @@ public:
   // of MinGW that define fileno as a macro.
   int (fileno)() const;
 
-  void print(fmt::StringRef format_str, const ArgList &args, const ArgMap &map) {
-    fmt::print(file_, format_str, args, map);
+  void print(fmt::StringRef format_str, const ArgList &args) {
+    fmt::print(file_, format_str, args);
   }
   FMT_VARIADIC(void, print, fmt::StringRef)
 };

--- a/posix.h
+++ b/posix.h
@@ -197,8 +197,8 @@ public:
   // of MinGW that define fileno as a macro.
   int (fileno)() const;
 
-  void print(fmt::StringRef format_str, const ArgList &args) {
-    fmt::print(file_, format_str, args);
+  void print(fmt::StringRef format_str, const ArgList &args, const ArgMap &map) {
+    fmt::print(file_, format_str, args, map);
   }
   FMT_VARIADIC(void, print, fmt::StringRef)
 };

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -606,6 +606,7 @@ TEST(FormatterTest, ManyArgs) {
   EXPECT_THROW_MSG(TestFormat<MAX_PACKED_ARGS>::format(format_str),
                    FormatError, "argument index out of range");
 }
+#endif
 
 TEST(FormatterTest, NamedArg) {
     char a = 'A', b = 'B', c = 'C';
@@ -620,7 +621,6 @@ TEST(FormatterTest, NamedArg) {
     EXPECT_EQ(" -42", format("{0:{width}}", -42, fmt::arg("width", 4)));
     EXPECT_EQ("st", format("{0:.{precision}}", "str", fmt::arg("precision", 2)));
 }
-#endif
 
 TEST(FormatterTest, AutoArgIndex) {
   EXPECT_EQ("abc", format("{}{}{}", 'a', 'b', 'c'));
@@ -1564,10 +1564,10 @@ TEST(StrTest, Convert) {
 }
 
 std::string format_message(int id, const char *format,
-    const fmt::ArgList &args, const fmt::ArgMap &map) {
+    const fmt::ArgList &args) {
   MemoryWriter w;
   w.write("[{}] ", id);
-  w.write(format, args, map);
+  w.write(format, args);
   return w.str();
 }
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -932,6 +932,32 @@ TEST(FormatterTest, RuntimeWidth) {
   format_str[size + 2] = 0;
   EXPECT_THROW_MSG(format(format_str, 0), FormatError, "number is too big");
 
+  EXPECT_THROW_MSG(format("{0:{", 0),
+      FormatError, "invalid format string");
+  EXPECT_THROW_MSG(format("{0:{}", 0),
+      FormatError, "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG(format("{0:{?}}", 0),
+      FormatError, "invalid format string");
+  EXPECT_THROW_MSG(format("{0:{1}}", 0),
+      FormatError, "argument index out of range");
+
+  EXPECT_THROW_MSG(format("{0:{0:}}", 0),
+      FormatError, "invalid format string");
+
+  EXPECT_THROW_MSG(format("{0:{1}}", 0, -1),
+      FormatError, "negative width");
+  EXPECT_THROW_MSG(format("{0:{1}}", 0, (INT_MAX + 1u)),
+      FormatError, "number is too big");
+  EXPECT_THROW_MSG(format("{0:{1}}", 0, -1l),
+      FormatError, "negative width");
+  if (fmt::internal::check(sizeof(long) > sizeof(int))) {
+    long value = INT_MAX;
+    EXPECT_THROW_MSG(format("{0:{1}}", 0, (value + 1)),
+        FormatError, "number is too big");
+  }
+  EXPECT_THROW_MSG(format("{0:{1}}", 0, (INT_MAX + 1ul)),
+      FormatError, "number is too big");
+
   EXPECT_THROW_MSG(format("{0:{1}}", 0, '0'),
       FormatError, "width is not integer");
   EXPECT_THROW_MSG(format("{0:{1}}", 0, 0.0),

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -613,6 +613,7 @@ TEST(FormatterTest, NamedArg) {
     EXPECT_EQ("BBAACC", format("{1}{b}{0}{a}{2}{c}", FMT_CAPTURE(a, b, c)));
     EXPECT_EQ(" A", format("{a:>2}", FMT_CAPTURE(a)));
     EXPECT_THROW_MSG(format("{a+}", FMT_CAPTURE(a)), FormatError, "missing '}' in format string");
+    EXPECT_THROW_MSG(format("{a}"), FormatError, "argument not found");
     EXPECT_THROW_MSG(format("{d}", FMT_CAPTURE(a, b, c)), FormatError, "argument not found");
     EXPECT_THROW_MSG(format("{a}{}", FMT_CAPTURE(a)),
         FormatError, "cannot switch from manual to automatic argument indexing");
@@ -620,6 +621,8 @@ TEST(FormatterTest, NamedArg) {
         FormatError, "cannot switch from automatic to manual argument indexing");
     EXPECT_EQ(" -42", format("{0:{width}}", -42, fmt::arg("width", 4)));
     EXPECT_EQ("st", format("{0:.{precision}}", "str", fmt::arg("precision", 2)));
+    int n = 100;
+    EXPECT_EQ(L"n=100", format(L"n={n}", FMT_CAPTURE_W(n)));
 }
 
 TEST(FormatterTest, AutoArgIndex) {


### PR DESCRIPTION
Allows code like below:
```c++
int x = 1, y = 2;
fmt::print("point: ({x}, {y})", FMT_CAPTURE(x, y));
```