### PR TITLE
Fix warnings

### DIFF
--- a/format.h
+++ b/format.h
@@ -1046,7 +1046,7 @@ struct NamedArg : Arg {
 
   template <typename T>
   NamedArg(BasicStringRef<Char> argname, const T &value)
-  : name(argname), Arg(MakeValue<Char>(value)) {
+  : Arg(MakeValue<Char>(value)), name(argname) {
     type = static_cast<internal::Arg::Type>(MakeValue<Char>::type(value));
   }
 };


### PR DESCRIPTION
Child attribute was being instantiated before parent attribute, gives warnings under GCC 4.9.1