### PR TITLE
add CMake option to toggle doxygen documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif ()
 option(FMT_PEDANTIC "Enable extra warnings and expensive tests." OFF)
 option(FMT_INSTALL "Generate install target." ON)
 option(FMT_TESTS "Generate tests." ON)
+option(FMT_DOCS "Generate doxygen documentation." ON)
 
 project(FORMAT)
 
@@ -114,7 +115,9 @@ endif ()
 set_target_properties(cppformat
   PROPERTIES COMPILE_FLAGS "${FMT_EXTRA_COMPILE_FLAGS}")
 
-add_subdirectory(doc)
+if (FMT_DOCS)
+  add_subdirectory(doc)
+endif ()
 
 if (FMT_TESTS)
   enable_testing()


### PR DESCRIPTION
Yet another PR, this time with the ability to toggle creation of doxygen documentation (on by default).

By the way, keep up the good work! :+1: 