### PR TITLE
User-defined literals for format and named arguments

### DIFF
--- a/format.h
+++ b/format.h
@@ -3030,6 +3030,16 @@ struct UdlFormat {
   }
 };
 
+template <typename Char>
+struct UdlArg {
+  const Char *str;
+
+  template <typename T>
+  NamedArg<Char> operator=(T &&value) const {
+    return {str, std::forward<T>(value)};
+  }
+};
+
 } // namespace internal
 
 inline namespace literals {
@@ -3038,6 +3048,11 @@ inline internal::UdlFormat<char>
 operator"" _format(const char *s, std::size_t) { return {s}; }
 inline internal::UdlFormat<wchar_t>
 operator"" _format(const wchar_t *s, std::size_t) { return {s}; }
+
+inline internal::UdlArg<char>
+operator"" _a(const char *s, std::size_t) { return {s}; }
+inline internal::UdlArg<wchar_t>
+operator"" _a(const wchar_t *s, std::size_t) { return {s}; }
 
 } // inline namespace literals
 } // namespace fmt

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1610,4 +1610,17 @@ TEST(LiteralsTest, Format) {
   EXPECT_EQ(format("{}c{}", "ab", 1), "{}c{}"_format("ab", 1));
   EXPECT_EQ(format(L"{}c{}", L"ab", 1), L"{}c{}"_format(L"ab", 1));
 }
+
+TEST(LiteralsTest, NamedArg) {
+  EXPECT_EQ(format("{first}{second}{first}{third}",
+                   fmt::arg("first", "abra"), fmt::arg("second", "cad"),
+                   fmt::arg("third", 99)),
+            format("{first}{second}{first}{third}",
+                   "first"_a="abra", "second"_a="cad", "third"_a=99));
+  EXPECT_EQ(format(L"{first}{second}{first}{third}",
+                   fmt::arg(L"first", L"abra"), fmt::arg(L"second", L"cad"),
+                   fmt::arg(L"third", 99)),
+            format(L"{first}{second}{first}{third}",
+                   L"first"_a=L"abra", L"second"_a=L"cad", L"third"_a=99));
+}
 #endif // FMT_USE_USER_DEFINED_LITERALS

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1602,3 +1602,12 @@ TEST(FormatTest, MaxArgs) {
             fmt::format("{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
                         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'a', 'b', 'c', 'd', 'e'));
 }
+
+#if FMT_USE_USER_DEFINED_LITERALS
+using namespace fmt::literals;
+
+TEST(LiteralsTest, Format) {
+  EXPECT_EQ(format("{}c{}", "ab", 1), "{}c{}"_format("ab", 1));
+  EXPECT_EQ(format(L"{}c{}", L"ab", 1), L"{}c{}"_format(L"ab", 1));
+}
+#endif // FMT_USE_USER_DEFINED_LITERALS


### PR DESCRIPTION
This is a bit of fun with C++11 user-defined literals. This brings C++ Format a little closer to Python's `str.format` for literals:

```Python
# Python
"{0}{1}{0}".format("abra", "cad")
```
```C++
// C++11 with user-defined literals
"{0}{1}{0}"_format("abra", "cad");
```
The literal `_format` just passes the arguments to `fmt::format` and is equivalent to `fmt::format("{0}{1}{0}", "abra", "cad");`

Literals can be used with named arguments as well:
```Python
# Python
"Hello, {name}! Your number is {number}".format(name="World", number=1);
```
```C++
// C++11 with user-defined literals
"Hello, {name}! Your number is {number}"_format("name"_a="World", "number"_a=1);
```

The `_a` literal just constructs a `fmt::arg` under the hood.

Compiler support for UDLs is required. Minimum Clang 3.1, GCC 4.7 or VS2015.
To use the literals `using namespace fmt::literals;` will import just `_format` and `_a`. But `using namespace fmt;` is also a possibility.