### PR TITLE
Update Sphinx with C++11 literals fix and add fmt::literals API docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -26,6 +26,8 @@ arguments in the resulting string.
 
 .. doxygenfunction:: format(CStringRef, ArgList)
 
+.. doxygenfunction:: operator""_format(const char *, std::size_t)
+
 .. _print:
 
 .. doxygenfunction:: print(CStringRef, ArgList)
@@ -73,6 +75,8 @@ Utilities
 =========
 
 .. doxygenfunction:: fmt::arg(StringRef, const T&)
+
+.. doxygenfunction:: operator""_a(const char *, std::size_t)
 
 .. doxygendefine:: FMT_CAPTURE
 

--- a/doc/build.py
+++ b/doc/build.py
@@ -30,7 +30,8 @@ def build_docs():
   activate_this_file = os.path.join(virtualenv_dir, 'bin', 'activate_this.py')
   execfile(activate_this_file, dict(__file__=activate_this_file))
   # Install Sphinx and Breathe.
-  pip_install('sphinx==1.3.1')
+  pip_install('sphinx-doc/sphinx',
+              '4d2c17e043d9e8197fa5cd0db34212af3bb17069')
   pip_install('michaeljones/breathe',
               '511b0887293e7c6b12310bb61b3659068f48f0f4')
   # Build docs.
@@ -53,7 +54,8 @@ def build_docs():
       ALIASES          += "endrst=\endverbatim"
       PREDEFINED        = _WIN32=1 \
                           FMT_USE_VARIADIC_TEMPLATES=1 \
-                          FMT_USE_RVALUE_REFERENCES=1
+                          FMT_USE_RVALUE_REFERENCES=1 \
+                          FMT_USE_USER_DEFINED_LITERALS=1
       EXCLUDE_SYMBOLS   = fmt::internal::* StringValue write_str
     '''.format(os.path.dirname(doc_dir)))
   if p.returncode != 0:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -165,7 +165,7 @@ Although the library uses C++11 features when available, it also works with olde
 compilers and standard library implementations. The only thing to keep in mind 
 for C++98 portability:
 
-* Variadic templates: minimum GCC 4.4, Clang 2.9 or VS2013. This feature allow 
+* Variadic templates: minimum GCC 4.4, Clang 2.9 or VS2013. This feature allows 
   the Format API to accept an unlimited number of arguments. With older compilers
   the maximum is 15.
 

--- a/format.h
+++ b/format.h
@@ -3044,11 +3044,31 @@ struct UdlArg {
 
 inline namespace literals {
 
+/**
+  \rst
+  C++11 literal equivalent of :func:`fmt::format`.
+
+  **Example**::
+  
+    using namespace fmt::literals;
+    std::string message = "The answer is {}"_format(42);
+  \endrst
+ */
 inline internal::UdlFormat<char>
 operator"" _format(const char *s, std::size_t) { return {s}; }
 inline internal::UdlFormat<wchar_t>
 operator"" _format(const wchar_t *s, std::size_t) { return {s}; }
 
+/**
+  \rst
+  C++11 literal equivalent of :func:`fmt::arg`.
+
+  **Example**::
+    
+    using namespace fmt::literals;
+    print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
+  \endrst
+ */
 inline internal::UdlArg<char>
 operator"" _a(const char *s, std::size_t) { return {s}; }
 inline internal::UdlArg<wchar_t>


### PR DESCRIPTION
Sphinx 1.3.1 can't parse user-defined literals. This updates the doc build script to the (currently) [latest state on the Sphinx master branch](https://github.com/sphinx-doc/sphinx/commit/4d2c17e043d9e8197fa5cd0db34212af3bb17069) which has the fix.

As for the `fmt::literals` API docs, the examples do most of the explaining. They mirror the `fmt::format` and `fmt::args` examples right above them. The description text just points to the equivalent function. I really couldn't think of anything to write in the description that would be clearer than the example.