### PR TITLE
Issue 205: Make iostream support optional.

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -1252,11 +1252,13 @@ FMT_FUNC void fmt::print(CStringRef format_str, ArgList args) {
   print(stdout, format_str, args);
 }
 
+#ifndef FMT_NO_STREAM_LIBRARIES
 FMT_FUNC void fmt::print(std::ostream &os, CStringRef format_str, ArgList args) {
   MemoryWriter w;
   w.write(format_str, args);
   os.write(w.data(), w.size());
 }
+#endif
 
 FMT_FUNC void fmt::print_colored(Color c, CStringRef format, ArgList args) {
   char escape[] = "\x1b[30m";

--- a/format.h
+++ b/format.h
@@ -38,8 +38,11 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
-#include <sstream>
 #include <map>
+
+#ifndef FMT_NO_STREAM_LIBRARIES
+# include <sstream>
+#endif
 
 #if _SECURE_SCL
 # include <iterator>
@@ -2685,6 +2688,8 @@ void print(std::FILE *f, CStringRef format_str, ArgList args);
  */
 void print(CStringRef format_str, ArgList args);
 
+
+#ifndef FMT_NO_STREAM_LIBRARIES
 /**
   \rst
   Prints formatted data to the stream *os*.
@@ -2695,6 +2700,7 @@ void print(CStringRef format_str, ArgList args);
   \endrst
  */
 void print(std::ostream &os, CStringRef format_str, ArgList args);
+#endif
 
 template <typename Char>
 void printf(BasicWriter<Char> &w, BasicCStringRef<Char> format, ArgList args) {
@@ -3007,7 +3013,11 @@ FMT_VARIADIC(std::string, format, CStringRef)
 FMT_VARIADIC_W(std::wstring, format, WCStringRef)
 FMT_VARIADIC(void, print, CStringRef)
 FMT_VARIADIC(void, print, std::FILE *, CStringRef)
+
+#ifndef FMT_NO_STREAM_LIBRARIES
 FMT_VARIADIC(void, print, std::ostream &, CStringRef)
+#endif
+
 FMT_VARIADIC(void, print_colored, Color, CStringRef)
 FMT_VARIADIC(std::string, sprintf, CStringRef)
 FMT_VARIADIC_W(std::wstring, sprintf, WCStringRef)

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1539,6 +1539,7 @@ TEST(FormatIntTest, FormatDec) {
   EXPECT_EQ("42", format_decimal(42ull));
 }
 
+#ifndef FMT_NO_STREAM_LIBRARIES
 TEST(FormatTest, Print) {
 #if FMT_USE_FILE_DESCRIPTORS
   EXPECT_WRITE(stdout, fmt::print("Don't {}!", "panic"), "Don't panic!");
@@ -1549,6 +1550,7 @@ TEST(FormatTest, Print) {
   fmt::print(os, "Don't {}!", "panic");
   EXPECT_EQ("Don't panic!", os.str());
 }
+#endif
 
 #if FMT_USE_FILE_DESCRIPTORS
 TEST(FormatTest, PrintColored) {


### PR DESCRIPTION
You can disable references to *stream libraries by defining FMT_NO_STREAM_LIBRARIES before including the headers.

```
#define FMT_NO_STREAM_LIBRARIES
#include <format.h>
```