### PR TITLE
Fix shared library build on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if (BIICODE)
 endif ()
 
 add_library(cppformat ${FMT_SOURCES})
-if (BUILD_SHARED_LIBS)
+if (BUILD_SHARED_LIBS AND UNIX AND NOT APPLE)
   # Fix rpmlint warning:
   # unused-direct-shlib-dependency /usr/lib/libformat.so.1.1.0 /lib/libm.so.6.
   target_link_libraries(cppformat -Wl,--as-needed)


### PR DESCRIPTION
I noticed this while trying to run format-benchmark. Building cppformat on OS X with `BUILD_SHARED_LIBS=ON` results in:
```
ld: unknown option: --as-needed
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libcppformat.1.2.0.dylib] Error 1
make[1]: *** [CMakeFiles/cppformat.dir/all] Error 2
make: *** [all] Error 2
```
This PR fixes it.


As a side note: The shared lib build is also broken with MSVC and it's a bit more elaborate. I don't think this is a big issue since a shared lib is probably not the optimal way to use cppformat. But just FYI.

This commit will resolve the `ignoring unknown flag --as-needed` warning on MSVC, but the build will still fail because it needs `__declspec(dllexport)` and `__declspec(dllimport)` to know which functions and classes to export. Those need to be behind macro defines and then peppered all over the code which can get quite ugly. Template instantiations can also complicate matters. The code uglification is probably a high price to pay for an almost-never-used feature. I am not advocating for it, but I can take a stab at making it work if there is interest.