### PR TITLE
MS Visual Studio "/Zc:wchar_t-" compiler parameter support added

### DIFF
--- a/format.h
+++ b/format.h
@@ -940,7 +940,9 @@ class MakeValue : public Arg {
   // characters and strings into narrow strings as in
   //   fmt::format("{}", L"test");
   // To fix this, use a wide format string: fmt::format(L"{}", L"test").
+#if !defined(_MSC_VER) || defined(_NATIVE_WCHAR_T_DEFINED)
   MakeValue(typename WCharHelper<wchar_t, Char>::Unsupported);
+#endif
   MakeValue(typename WCharHelper<wchar_t *, Char>::Unsupported);
   MakeValue(typename WCharHelper<const wchar_t *, Char>::Unsupported);
   MakeValue(typename WCharHelper<const std::wstring &, Char>::Unsupported);
@@ -977,7 +979,9 @@ class MakeValue : public Arg {
 
   FMT_MAKE_VALUE(bool, int_value, BOOL)
   FMT_MAKE_VALUE(short, int_value, INT)
+#if !defined(_MSC_VER) || defined(_NATIVE_WCHAR_T_DEFINED)
   FMT_MAKE_VALUE(unsigned short, uint_value, UINT)
+#endif
   FMT_MAKE_VALUE(int, int_value, INT)
   FMT_MAKE_VALUE(unsigned, uint_value, UINT)
 


### PR DESCRIPTION
If ```/Zc:wchar_t-``` compiler parameter is specified, then ```wchar_t``` is defined as
```typedef unsigned short wchar_t;```
Thus, this leads to conflict in template definition in ```format.h```

You can verify it in any Visual Studio project with spdlog with 
```
set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:wchar_t-")
```

reference: https://msdn.microsoft.com/ru-ru/library/dh8che7s.aspx