### PR TITLE
Fix warnings

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -55,7 +55,7 @@ using fmt::internal::Arg;
 #if __GNUC__ && !__EXCEPTIONS
 # define FMT_EXCEPTIONS 0
 #endif
-#if _MSC_VER && !_HAS_EXCEPTIONS
+#if defined(_MSC_VER) && !_HAS_EXCEPTIONS
 # define FMT_EXCEPTIONS 0
 #endif
 #ifndef FMT_EXCEPTIONS
@@ -84,7 +84,7 @@ using fmt::internal::Arg;
 # define FMT_FUNC
 #endif
 
-#if _MSC_VER
+#ifdef _MSC_VER
 # pragma warning(push)
 # pragma warning(disable: 4127)  // conditional expression is constant
 # pragma warning(disable: 4702)  // unreachable code
@@ -1325,6 +1325,6 @@ template int fmt::internal::CharTraits<wchar_t>::format_float(
 
 #endif  // FMT_HEADER_ONLY
 
-#if _MSC_VER
+#ifdef _MSC_VER
 # pragma warning(pop)
 #endif

--- a/format.h
+++ b/format.h
@@ -594,6 +594,15 @@ inline int isinfinity(long double x) { return isinf(x); }
 inline int isinfinity(double x) { return std::isinf(x); }
 inline int isinfinity(long double x) { return std::isinf(x); }
 # endif
+
+// Portable version of isnan.
+# ifdef isnan
+inline int isnotanumber(double x) { return isnan(x); }
+inline int isnotanumber(long double x) { return isnan(x); }
+# else
+inline int isnotanumber(double x) { return std::isnan(x); }
+inline int isnotanumber(long double x) { return std::isnan(x); }
+# endif
 #else
 inline int getsign(double value) {
   if (value < 0) return 1;
@@ -606,6 +615,10 @@ inline int getsign(double value) {
 inline int isinfinity(double x) { return !_finite(x); }
 inline int isinfinity(long double x) {
   return !_finite(static_cast<double>(x));
+}
+inline int isnotanumber(double x) { return _isnan(x); }
+inline int isnotanumber(long double x) {
+    return _isnan(static_cast<double>(x));
 }
 #endif
 
@@ -2378,7 +2391,7 @@ void BasicWriter<Char>::write_double(
     sign = spec.flag(PLUS_FLAG) ? '+' : ' ';
   }
 
-  if (value != value) {
+  if (internal::isnotanumber(value)) {
     // Format NaN ourselves because sprintf's output is not consistent
     // across platforms.
     std::size_t nan_size = 4;

--- a/format.h
+++ b/format.h
@@ -48,6 +48,10 @@
 # include <sstream>
 #endif
 
+#ifndef _SECURE_SCL
+# define _SECURE_SCL 0
+#endif
+
 #if _SECURE_SCL
 # include <iterator>
 #endif
@@ -160,6 +164,10 @@ inline uint32_t clzll(uint64_t x) {
 #endif
 
 // Define FMT_USE_NOEXCEPT to make C++ Format use noexcept (C++11 feature).
+#ifndef FMT_USE_NOEXCEPT
+# define FMT_USE_NOEXCEPT 0
+#endif
+
 #ifndef FMT_NOEXCEPT
 # if FMT_USE_NOEXCEPT || FMT_HAS_FEATURE(cxx_noexcept) || \
    (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
@@ -172,6 +180,10 @@ inline uint32_t clzll(uint64_t x) {
 
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class
+#ifndef FMT_USE_DELETED_FUNCTIONS
+# define FMT_USE_DELETED_FUNCTIONS 0
+#endif
+
 #if FMT_USE_DELETED_FUNCTIONS || FMT_HAS_FEATURE(cxx_deleted_functions) || \
   (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1800
 # define FMT_DELETED_OR_UNDEFINED  = delete
@@ -2434,7 +2446,7 @@ void BasicWriter<Char>::write_double(
   Char fill = internal::CharTraits<Char>::cast(spec.fill());
   for (;;) {
     std::size_t buffer_size = buffer_.capacity() - offset;
-#if _MSC_VER
+#ifdef _MSC_VER
     // MSVC's vsnprintf_s doesn't work with zero size, so reserve
     // space for at least one extra character to make the size non-zero.
     // Note that the buffer's capacity will increase by more than 1.

--- a/posix.h
+++ b/posix.h
@@ -69,6 +69,10 @@
 # define FMT_UNUSED
 #endif
 
+#ifndef FMT_USE_STATIC_ASSERT
+# define FMT_USE_STATIC_ASSERT 0
+#endif
+
 #if FMT_USE_STATIC_ASSERT || FMT_HAS_CPP_ATTRIBUTE(cxx_static_assert) || \
   (FMT_GCC_VERSION >= 403 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1600
 # define FMT_STATIC_ASSERT(cond, message) static_assert(cond, message)


### PR DESCRIPTION
These two commits fix a number of warnings when compiling with the gcc options -Wundef and -Wfloat-equal.

The first commit is pretty straight-forward: Use #ifdef instead of #if when checking _MSC_VER, and set a default value for options like FMT_USE_NOEXCEPT when undefined.

The second commit replaces a (value != value) expression used to test whether a floating point number is NaN with an explicit call to isnan(). I added a set of compatibility functions similar to those for isinf(), but I have not tested them with any compiler other than gcc.