### PR TITLE
Fix warnings

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -1265,7 +1265,7 @@ FMT_FUNC void fmt::print(std::ostream &os, CStringRef format_str, ArgList args) 
 
 FMT_FUNC void fmt::print_colored(Color c, CStringRef format, ArgList args) {
   char escape[] = "\x1b[30m";
-  escape[3] = '0' + static_cast<char>(c);
+  escape[3] = static_cast<char>('0' + c);
   std::fputs(escape, stdout);
   print(format, args);
   std::fputs(RESET_COLOR, stdout);

--- a/format.cc
+++ b/format.cc
@@ -52,7 +52,7 @@
 using fmt::internal::Arg;
 
 // Check if exceptions are disabled.
-#if __GNUC__ && !__EXCEPTIONS
+#if defined(__GNUC__) && !defined(__EXCEPTIONS)
 # define FMT_EXCEPTIONS 0
 #endif
 #if defined(_MSC_VER) && !_HAS_EXCEPTIONS

--- a/format.h
+++ b/format.h
@@ -778,7 +778,7 @@ inline void format_decimal(Char *buffer, UInt value, unsigned num_digits) {
     // Integer division is slow so do it for a group of two digits instead
     // of for every digit. The idea comes from the talk by Alexandrescu
     // "Three Optimization Tips for C++". See speed-test for a comparison.
-    unsigned index = (value % 100) * 2;
+    unsigned index = static_cast<unsigned>((value % 100) * 2);
     value /= 100;
     *--buffer = Data::DIGITS[index + 1];
     *--buffer = Data::DIGITS[index];
@@ -2330,7 +2330,7 @@ void BasicWriter<Char>::write_int(T value, Spec spec) {
     Char *p = get(prepare_int_buffer(num_digits, spec, prefix, prefix_size));
     n = abs_value;
     do {
-      *p-- = '0' + (n & 1);
+      *p-- = static_cast<Char>('0' + (n & 1));
     } while ((n >>= 1) != 0);
     break;
   }
@@ -2345,7 +2345,7 @@ void BasicWriter<Char>::write_int(T value, Spec spec) {
     Char *p = get(prepare_int_buffer(num_digits, spec, prefix, prefix_size));
     n = abs_value;
     do {
-      *p-- = '0' + (n & 7);
+      *p-- = static_cast<Char>('0' + (n & 7));
     } while ((n >>= 3) != 0);
     break;
   }
@@ -2810,7 +2810,7 @@ class FormatInt {
       // Integer division is slow so do it for a group of two digits instead
       // of for every digit. The idea comes from the talk by Alexandrescu
       // "Three Optimization Tips for C++". See speed-test for a comparison.
-      unsigned index = (value % 100) * 2;
+      unsigned index = static_cast<unsigned>((value % 100) * 2);
       value /= 100;
       *--buffer_end = internal::Data::DIGITS[index + 1];
       *--buffer_end = internal::Data::DIGITS[index];

--- a/format.h
+++ b/format.h
@@ -105,6 +105,9 @@ inline uint32_t clzll(uint64_t x) {
 // Disable the warning about declaration shadowing because it affects too
 // many valid cases.
 #  pragma GCC diagnostic ignored "-Wshadow"
+// Disable the warning about implicit conversions that may change the sign of
+// an integer; silencing it otherwise would require many explicit casts.
+#  pragma GCC diagnostic ignored "-Wsign-conversion"
 # endif
 # if __cplusplus >= 201103L || defined __GXX_EXPERIMENTAL_CXX0X__
 #  define FMT_HAS_GXX_CXX11 1

--- a/format.h
+++ b/format.h
@@ -911,7 +911,7 @@ struct WCharHelper<T, wchar_t> {
 
 template <typename T>
 class IsConvertibleToInt {
- private:
+ protected:
   typedef char yes[1];
   typedef char no[2];
 


### PR DESCRIPTION
Even more fixes for optional GCC warnings:

* When building with -Wctor-dtor-privacy, gcc mistakenly assumes that the IsConvertibleToInt template class is unusable. Method visibility changed from private to protected as a workaround.
* Add a few explicit casts to silence -Wconversion warnings.
* Disable sign-compare warning in the header. Silencing the warning otherwise would require many explicit casts due to the C/C++ integer promotion rules.
* Test GCC macros __GNUC__ and __EXCEPTIONS for presence instead of value.