### PR TITLE
Fix static_assert feature detection on clang

### DIFF
--- a/posix.h
+++ b/posix.h
@@ -73,7 +73,7 @@
 # define FMT_USE_STATIC_ASSERT 0
 #endif
 
-#if FMT_USE_STATIC_ASSERT || FMT_HAS_CPP_ATTRIBUTE(cxx_static_assert) || \
+#if FMT_USE_STATIC_ASSERT || FMT_HAS_FEATURE(cxx_static_assert) || \
   (FMT_GCC_VERSION >= 403 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1600
 # define FMT_STATIC_ASSERT(cond, message) static_assert(cond, message)
 #else


### PR DESCRIPTION
I had an unused typedef warning as shown below. Looks like `static_assert` couldn't be found on clang
This PR fixes it.

```
cppformat/posix.cc:162:3: warning: unused typedef 'Assert163'
      [-Wunused-local-typedef]
  FMT_STATIC_ASSERT(sizeof(fmt::LongLong) >= sizeof(file_stat.st_size),
  ^
```