### PR TITLE
Fix warning when using Intel C++ on OS X

### DIFF
--- a/format.h
+++ b/format.h
@@ -116,7 +116,7 @@ inline uint32_t clzll(uint64_t x) {
 # define FMT_GCC_EXTENSION
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wdocumentation"
 #endif
@@ -3146,7 +3146,7 @@ operator"" _a(const wchar_t *s, std::size_t) { return {s}; }
 # pragma GCC diagnostic pop
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 # pragma clang diagnostic pop
 #endif
 


### PR DESCRIPTION
Unfortunately, Intel's C++ compiler defines `__clang__` which means that
some of the pragmas in use that Intel C++ doesn't use will cause
warnings to be generated.