### PR TITLE
Fix fmt::BufferedFile::fileno not compiling with Android NDK.

### DIFF
--- a/posix.cc
+++ b/posix.cc
@@ -102,8 +102,8 @@ void fmt::BufferedFile::close() {
 // A macro used to prevent expansion of fileno on broken versions of MinGW.
 #define FMT_ARGS
 
-int fmt::BufferedFile::fileno() const {
-  int fd = FMT_POSIX_CALL(fileno FMT_ARGS(file_));
+int fmt::BufferedFile::fileno_() const {
+  int fd = FMT_SYSTEM(fileno FMT_ARGS(file_));
   if (fd == -1)
     throw SystemError(errno, "cannot get file descriptor");
   return fd;

--- a/posix.h
+++ b/posix.h
@@ -195,7 +195,7 @@ public:
 
   // We place parentheses around fileno to workaround a bug in some versions
   // of MinGW that define fileno as a macro.
-  int (fileno)() const;
+  int (fileno_)() const;
 
   void print(CStringRef format_str, const ArgList &args) {
     fmt::print(file_, format_str, args);

--- a/test/gtest-extra-test.cc
+++ b/test/gtest-extra-test.cc
@@ -369,7 +369,7 @@ TEST(OutputRedirectTest, FlushErrorInCtor) {
 
 TEST(OutputRedirectTest, DupErrorInCtor) {
   BufferedFile f = open_buffered_file();
-  int fd = (f.fileno)();
+  int fd = (f.fileno_)();
   File copy = File::dup(fd);
   FMT_POSIX(close(fd));
   scoped_ptr<OutputRedirect> redir;

--- a/test/posix-mock-test.cc
+++ b/test/posix-mock-test.cc
@@ -445,7 +445,7 @@ TEST(BufferedFileTest, FilenoNoRetry) {
   File::pipe(read_end, write_end);
   BufferedFile f = read_end.fdopen("r");
   fileno_count = 1;
-  EXPECT_SYSTEM_ERROR((f.fileno)(), EINTR, "cannot get file descriptor");
+  EXPECT_SYSTEM_ERROR((f.fileno_)(), EINTR, "cannot get file descriptor");
   EXPECT_EQ(2, fileno_count);
   fileno_count = 0;
 }

--- a/test/posix-test.cc
+++ b/test/posix-test.cc
@@ -103,7 +103,7 @@ TEST(BufferedFileTest, MoveAssignment) {
 TEST(BufferedFileTest, MoveAssignmentClosesFile) {
   BufferedFile bf = open_buffered_file();
   BufferedFile bf2 = open_buffered_file();
-  int old_fd = bf2.fileno();
+  int old_fd = bf2.fileno_();
   bf2 = std::move(bf);
   EXPECT_TRUE(isclosed(old_fd));
 }
@@ -123,7 +123,7 @@ TEST(BufferedFileTest, MoveFromTemporaryInAssignment) {
 
 TEST(BufferedFileTest, MoveFromTemporaryInAssignmentClosesFile) {
   BufferedFile f = open_buffered_file();
-  int old_fd = f.fileno();
+  int old_fd = f.fileno_();
   f = open_buffered_file();
   EXPECT_TRUE(isclosed(old_fd));
 }
@@ -132,7 +132,7 @@ TEST(BufferedFileTest, CloseFileInDtor) {
   int fd = 0;
   {
     BufferedFile f = open_buffered_file();
-    fd = f.fileno();
+    fd = f.fileno_();
   }
   EXPECT_TRUE(isclosed(fd));
 }
@@ -144,14 +144,14 @@ TEST(BufferedFileTest, CloseErrorInDtor) {
       // the system may recycle closed file descriptor when redirecting the
       // output in EXPECT_STDERR and the second close will break output
       // redirection.
-      FMT_POSIX(close(f->fileno()));
+      FMT_POSIX(close(f->fileno_()));
       SUPPRESS_ASSERT(f.reset());
   }, format_system_error(EBADF, "cannot close file") + "\n");
 }
 
 TEST(BufferedFileTest, Close) {
   BufferedFile f = open_buffered_file();
-  int fd = f.fileno();
+  int fd = f.fileno_();
   f.close();
   EXPECT_TRUE(f.get() == 0);
   EXPECT_TRUE(isclosed(fd));
@@ -159,7 +159,7 @@ TEST(BufferedFileTest, Close) {
 
 TEST(BufferedFileTest, CloseError) {
   BufferedFile f = open_buffered_file();
-  FMT_POSIX(close(f.fileno()));
+  FMT_POSIX(close(f.fileno_()));
   EXPECT_SYSTEM_ERROR_NOASSERT(f.close(), EBADF, "cannot close file");
   EXPECT_TRUE(f.get() == 0);
 }
@@ -171,15 +171,15 @@ TEST(BufferedFileTest, Fileno) {
   // Disable Coverity because this is intentional.
   EXPECT_DEATH_IF_SUPPORTED({
     try {
-      f.fileno();
+      f.fileno_();
     } catch (fmt::SystemError) {
       std::exit(1);
     }
   }, "");
 #endif
   f = open_buffered_file();
-  EXPECT_TRUE(f.fileno() != -1);
-  File copy = File::dup(f.fileno());
+  EXPECT_TRUE(f.fileno_() != -1);
+  File copy = File::dup(f.fileno_());
   EXPECT_READ(copy, FILE_CONTENT);
 }
 


### PR DESCRIPTION
With Android NDK arm7 gcc 4.9, `fileno` is defined as a macro, so calling `fileno` with the scope operators will fail. Therefore `FMT_POSIX_CALL` is replaced with `FMT_SYSTEM`. `BufferedFile::fileno` has also been renamed to `fileno_` to avoid conflicts with the global `fileno` macro.

I'm a bit unsure about using `FMT_SYSTEM`, but at least it solves the problem for me.