### PR TITLE
Fix fileno causing compile error when #defined

### DIFF
--- a/posix.cc
+++ b/posix.cc
@@ -55,10 +55,13 @@
 
 # ifdef __MINGW32__
 #  define _SH_DENYNO 0x40
-#  undef fileno
 # endif
 
 #endif  // _WIN32
+
+#ifdef fileno
+# undef fileno
+#endif
 
 namespace {
 #ifdef _WIN32


### PR DESCRIPTION
Error:
expected unqualified-id before '(' token
 int fmt::BufferedFile::fileno() const {

This is an issue with Android NDK and mingw32.