### PR TITLE
Reduce compile time of variadic functions

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -304,20 +304,20 @@ class ArgConverter : public fmt::internal::ArgVisitor<ArgConverter<T>, void> {
       // Extra casts are used to silence warnings.
       if (is_signed) {
         arg_.type = Arg::INT;
-        arg_.int_value = static_cast<int>(static_cast<T>(value));
+        arg_.value.int_value = static_cast<int>(static_cast<T>(value));
       } else {
         arg_.type = Arg::UINT;
-        arg_.uint_value = static_cast<unsigned>(
+        arg_.value.uint_value = static_cast<unsigned>(
             static_cast<typename fmt::internal::MakeUnsigned<T>::Type>(value));
       }
     } else {
       if (is_signed) {
         arg_.type = Arg::LONG_LONG;
-        arg_.long_long_value =
+        arg_.value.long_long_value =
             static_cast<typename fmt::internal::MakeUnsigned<U>::Type>(value);
       } else {
         arg_.type = Arg::ULONG_LONG;
-        arg_.ulong_long_value =
+        arg_.value.ulong_long_value =
             static_cast<typename fmt::internal::MakeUnsigned<U>::Type>(value);
       }
     }
@@ -337,7 +337,7 @@ class CharConverter : public fmt::internal::ArgVisitor<CharConverter, void> {
   template <typename T>
   void visit_any_int(T value) {
     arg_.type = Arg::CHAR;
-    arg_.int_value = static_cast<char>(value);
+    arg_.value.int_value = static_cast<char>(value);
   }
 };
 }  // namespace
@@ -405,7 +405,7 @@ class PrintfArgFormatter :
     write_null_pointer();
   }
 
-  void visit_custom(Arg::CustomValue c) {
+  void visit_custom(Value::CustomValue c) {
     BasicFormatter<Char> formatter(ArgList(), this->writer());
     const Char format_str[] = {'}', 0};
     const Char *format = format_str;
@@ -627,7 +627,7 @@ void fmt::internal::ArgMap<Char>::init(const ArgList &args) {
   for (unsigned i = 0; i != ArgList::MAX_PACKED_ARGS; ++i) {
     internal::Arg::Type arg_type = args.type(i);
     if (arg_type == internal::Arg::NAMED_ARG) {
-      named_arg = static_cast<const NamedArg*>(args.args_[i].pointer);
+      named_arg = static_cast<const NamedArg*>(args.args_[i].value.pointer);
       map_.insert(Pair(named_arg->name, *named_arg));
     }
   }
@@ -636,7 +636,7 @@ void fmt::internal::ArgMap<Char>::init(const ArgList &args) {
     case internal::Arg::NONE:
       return;
     case internal::Arg::NAMED_ARG:
-      named_arg = static_cast<const NamedArg*>(args.args_[i].pointer);
+      named_arg = static_cast<const NamedArg*>(args.args_[i].value.pointer);
       map_.insert(Pair(named_arg->name, *named_arg));
       break;
     default:
@@ -658,7 +658,7 @@ FMT_FUNC Arg fmt::internal::FormatterBase::do_get_arg(
     error = "argument index out of range";
     break;
   case Arg::NAMED_ARG:
-    arg = *static_cast<const internal::Arg*>(arg.pointer);
+    arg = *static_cast<const internal::Arg*>(arg.value.pointer);
   default:
     /*nothing*/;
   }

--- a/format.h
+++ b/format.h
@@ -1218,14 +1218,9 @@ template <typename Char>
 struct NamedArg : Arg {
   BasicStringRef<Char> name;
 
-  typedef internal::MakeValue< BasicFormatter<Char> > MakeValue;
-
   template <typename T>
   NamedArg(BasicStringRef<Char> argname, const T &x)
-  : name(argname) {
-    value = MakeValue(x);
-    type = static_cast<Arg::Type>(MakeValue::type(x));
-  }
+  : Arg(internal::MakeArg< BasicFormatter<Char> >(x)), name(argname) {}
 };
 
 #define FMT_DISPATCH(call) static_cast<Impl*>(this)->call
@@ -2900,11 +2895,8 @@ void format(BasicFormatter<Char> &f, const Char *&format_str, const T &value) {
   output << value;
 
   BasicStringRef<Char> str(&buffer[0], format_buf.size());
-  typedef internal::MakeValue< BasicFormatter<Char> > MakeValue;
-  internal::Arg arg;
-  arg.value = MakeValue(str);
-  arg.type = static_cast<internal::Arg::Type>(MakeValue::type(str));
-  format_str = f.format(format_str, arg);
+  typedef internal::MakeArg< BasicFormatter<Char> > MakeArg;
+  format_str = f.format(format_str, MakeArg(str));
 }
 
 // Reports a system error without throwing an exception.

--- a/format.h
+++ b/format.h
@@ -1902,11 +1902,13 @@ inline uint64_t make_type(const T &arg) {
 #if FMT_USE_VARIADIC_TEMPLATES
 
 template <typename Formatter, unsigned N>
-using ArgArray = typename Conditional<
-  N < ArgList::MAX_PACKED_ARGS,
-  MakeValue<Formatter>[(N > 0) ? N : 1],
-  MakeArg<Formatter>[N + 1]
->::type;
+struct ArgArray {
+  typedef typename Conditional<
+    N < ArgList::MAX_PACKED_ARGS,
+    MakeValue<Formatter>[(N > 0) ? N : 1],
+    MakeArg<Formatter>[N + 1]
+  >::type Type;
+};
 
 template <typename Arg, typename... Args>
 inline uint64_t make_type(const Arg &first, const Args & ... tail) {
@@ -1992,7 +1994,8 @@ class FormatBuf : public std::basic_streambuf<Char> {
 # define FMT_VARIADIC_VOID(func, arg_type) \
   template <typename... Args> \
   void func(arg_type arg0, const Args & ... args) { \
-    fmt::internal::ArgArray<fmt::BasicFormatter<Char>, sizeof...(Args)> array{args...}; \
+    typename fmt::internal::ArgArray< \
+      fmt::BasicFormatter<Char>, sizeof...(Args)>::Type array{args...}; \
     func(arg0, fmt::ArgList(fmt::internal::make_type(args...), array)); \
   }
 
@@ -2000,7 +2003,8 @@ class FormatBuf : public std::basic_streambuf<Char> {
 # define FMT_VARIADIC_CTOR(ctor, func, arg0_type, arg1_type) \
   template <typename... Args> \
   ctor(arg0_type arg0, arg1_type arg1, const Args & ... args) { \
-    fmt::internal::ArgArray<fmt::BasicFormatter<Char>, sizeof...(Args)> array{args...}; \
+    typename fmt::internal::ArgArray< \
+      fmt::BasicFormatter<Char>, sizeof...(Args)>::Type array{args...}; \
     func(arg0, arg1, fmt::ArgList(fmt::internal::make_type(args...), array)); \
   }
 
@@ -3218,7 +3222,8 @@ void arg(WStringRef, const internal::NamedArg<Char>&) FMT_DELETED_OR_UNDEFINED;
   template <typename... Args> \
   ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__), \
       const Args & ... args) { \
-    fmt::internal::ArgArray<fmt::BasicFormatter<Char>, sizeof...(Args)> array{args...}; \
+    typename fmt::internal::ArgArray< \
+      fmt::BasicFormatter<Char>, sizeof...(Args)>::Type array{args...}; \
     call(FMT_FOR_EACH(FMT_GET_ARG_NAME, __VA_ARGS__), \
       fmt::ArgList(fmt::internal::make_type(args...), array)); \
   }

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -42,7 +42,7 @@ TEST(FormatTest, ArgConverter) {
   using fmt::internal::Arg;
   Arg arg = Arg();
   arg.type = Arg::LONG_LONG;
-  arg.long_long_value = std::numeric_limits<fmt::LongLong>::max();
+  arg.value.long_long_value = std::numeric_limits<fmt::LongLong>::max();
   fmt::ArgConverter<fmt::LongLong>(arg, 'd').visit(arg);
   EXPECT_EQ(Arg::LONG_LONG, arg.type);
 }

--- a/test/macro-test.cc
+++ b/test/macro-test.cc
@@ -70,7 +70,7 @@ int result;
   void func(const char *format, const fmt::ArgList &args) { \
     result = 0; \
     for (unsigned i = 0; args[i].type; ++i) \
-      result += args[i].int_value; \
+      result += args[i].value.int_value; \
   }
 
 MAKE_TEST(test_func)
@@ -101,7 +101,7 @@ struct S {};
 int test_variadic(FMT_GEN(10, GET_TYPE), const fmt::ArgList &args) { \
   int result = 0; \
   for (unsigned i = 0; args[i].type; ++i) \
-    result += args[i].int_value; \
+    result += args[i].value.int_value; \
   return result;
 }
 FMT_VARIADIC(int, test_variadic,

--- a/test/util-test.cc
+++ b/test/util-test.cc
@@ -114,6 +114,20 @@ TEST(BufferTest, Nonmoveable) {
   EXPECT_FALSE(std::is_move_constructible<Buffer<char> >::value);
   EXPECT_FALSE(std::is_move_assignable<Buffer<char> >::value);
 }
+
+TEST(ArgArrayTest, ValueTraits) {
+  typedef fmt::internal::MakeValue< fmt::BasicFormatter<char> > MakeValue;
+  EXPECT_TRUE(std::is_pod<Value>::value);
+  EXPECT_TRUE(std::is_standard_layout<MakeValue>::value);
+  EXPECT_EQ(sizeof(Value[2]), sizeof(MakeValue[2]));
+}
+
+TEST(ArgArrayTest, ArgTraits) {
+  typedef fmt::internal::MakeArg< fmt::BasicFormatter<char> > MakeArg;
+  EXPECT_TRUE(std::is_pod<Arg>::value);
+  EXPECT_TRUE(std::is_standard_layout<MakeArg>::value);
+  EXPECT_EQ(sizeof(Arg[2]), sizeof(MakeArg[2]));
+}
 #endif
 
 // A test buffer with a dummy grow method.


### PR DESCRIPTION
The proposed PR would reduce the compile time of variadic templates like `fmt::print` and `fmt::format`. The improvement on bloat-test is small but measurable (reduced from 35 to 33 seconds on my system), but that doesn't tell the whole story.

In order to get a more detailed measurement I modified bloat-test to generate tests for any number of arguments. The resulting variadic-test can be [found here](https://github.com/dean0x7d/format-benchmark/commit/fd4e429956ce52ae1bfdd752a9fdbcbaa81b1075). When invoked with `make variadic-test ARGS="1 25 10"` it will generate `fmt::print` statements with `1 <= x < 25` arguments and it will compile each with `10` translation units.

### Results

The following figures show the results for Clang and GCC, before and after the proposed PR changes. The data is gathered from `make variadic-test ARGS="1 25 10"`. Clang 7 was tested on OS X 10.11, while GCC 5.2 was on Antergos (Arch).

#### Compile time

![appleclang_time](https://cloud.githubusercontent.com/assets/4831417/11614060/b9e826d2-9c36-11e5-8666-d4131bf503ef.png)

![gcc5_time](https://cloud.githubusercontent.com/assets/4831417/11614080/6ac903cc-9c37-11e5-8165-26df6efae364.png)

#### Binary size

![appleclang_size](https://cloud.githubusercontent.com/assets/4831417/11614085/89a89384-9c37-11e5-9fa3-681a74fd52a1.png)

![gcc5_size](https://cloud.githubusercontent.com/assets/4831417/11614092/903674fa-9c37-11e5-9707-7f50a5a2dd7d.png)


### The Good

Clang benefits the most. With the current implementation there is a weird spike between 8 and 12 arguments in release mode. This spike gets ironed out with the proposed changes and there is a nice overall speed up.

GCC also sees some strange compile time spikes at 20 and 22 arguments - these show up consistently for me. The proposed changes clear that up and there is an overall speedup, although a bit hard to see in the figure because the two spikes mess with the scale.

There is a small binary size improvement for GCC with `> 16` arguments in release mode.

Debug mode sees benefits across the board. Not that important, but nice.

### The Bad

Both GCC and Clang see a binary size regression at exactly 16 arguments (clearly visible in the figures). This is because the proposed implementation must generate all unpacked types for `>=16` arguments, while currently 16 is a special case with part packed and part unpacked types.

### The Ugly

The proposed implementation replaces the `ArgArray` type from `Value[]`/`Arg[]` to `MakeValue[]`/`MakeArg[]`. When the argument array is passed, it's implicitly converted in the chain `MakeValue[]` -> `MakeValue*` -> `Value*`, and `Value*` is then used as `Value[]`. This works fine because `MakeValue` and `Value` are equivalent, standard layout types, but I feel bad writing it...
If `Value` and `MakeValue` change so they are not equivalent, the code will still compile, but it will not work correctly. I added tests to trigger in this case.

##### Alternatives

I attempted a few alternatives for the ugly bit, but they didn't fare too well. This
```c++
MakeValue<Char>[] value = {args...};
```
could be avoided by writing this
```c++
Value[] = {make_arg<Char>(args, is_packed_tag{})...};
```
where `is_packed_tag` would select if a `Value` or `Arg` should be created. Unfortunately, this results in a huge increase in binary size on GCC, which refuses to inline more than 6 or 7 arguments.

The array could be placed into a struct:
```c++
template <unsigned N>
struct ArgArray {
    Value data[N];

    template <typename... Args>
    ArgArray(const Args & ... args) : data{make_arg<Char>(args, is_packed_tag{})...} {}
}
```
This restores proper inlining on GCC, but the compile time becomes much worse.

### Epilogue

This started because I noticed that compile times were slower on Clang than on GCC which is not something I usually see. I may have fallen into a rabbit hole, but it's been interesting. There are tradeoffs as outlined above, so I'd understand if the proposed changes aren't completely desirable, but I hope at least some part will be useful.