### PR TITLE
Add fprintf overload that writes to a std::ostream

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -882,6 +882,13 @@ FMT_FUNC int fmt::fprintf(std::FILE *f, CStringRef format, ArgList args) {
   return std::fwrite(w.data(), 1, size, f) < size ? -1 : static_cast<int>(size);
 }
 
+FMT_FUNC int fmt::fprintf(std::ostream &os, CStringRef format, ArgList args) {
+  MemoryWriter w;
+  printf(w, format, args);
+  os.write(w.data(), w.size());
+  return static_cast<int>(w.size());
+}
+
 #ifndef FMT_HEADER_ONLY
 
 template struct fmt::internal::BasicData<void>;

--- a/format.h
+++ b/format.h
@@ -3366,6 +3366,18 @@ FMT_VARIADIC(int, fprintf, std::FILE *, CStringRef)
  */
 FMT_API void print(std::ostream &os, CStringRef format_str, ArgList args);
 FMT_VARIADIC(void, print, std::ostream &, CStringRef)
+
+/**
+  \rst
+  Prints formatted data to the stream *os*.
+
+  **Example**::
+
+    fprintf(cerr, "Don't %s!", "panic");
+  \endrst
+ */
+FMT_API int fprintf(std::ostream &os, CStringRef format_str, ArgList args);
+FMT_VARIADIC(int, fprintf, std::ostream &, CStringRef)
 #endif
 
 namespace internal {

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -476,3 +476,10 @@ TEST(PrintfTest, PrintfError) {
 TEST(PrintfTest, WideString) {
   EXPECT_EQ(L"abc", fmt::sprintf(L"%s", TestWString(L"abc")));
 }
+
+TEST(PrintfTest, Iostream) {
+  std::ostringstream os;
+  int ret = fmt::fprintf(os, "Don't %s!", "panic");
+  EXPECT_EQ("Don't panic!", os.str());
+  EXPECT_EQ(12, ret);
+}


### PR DESCRIPTION
For completeness, add an overload for fprintf that writes to a std::ostream.