### PR TITLE
Fixed macro redefinition warnings when compiling with clang-cl.

### DIFF
--- a/format.h
+++ b/format.h
@@ -75,7 +75,7 @@ typedef __int64          intmax_t;
 # define FMT_API
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 # include <intrin.h>  // _BitScanReverse, _BitScanReverse64
 
 namespace fmt {


### PR DESCRIPTION
Both clang-cl and Clang/C2 #define `_MSC_VER` but also have support for `__builtin_clz` and `__builtin_clzll`, leading to duplicate macro definition warnings. This change suppresses emulation of clz using `_BitScanReverse` if the `__clang__` macro is defined.