### PR TITLE
Ignore breathe and /doc/sphinx-bootstrap-theme directories in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ bin/
 /doc/doxyxml
 /doc/html
 /doc/virtualenv
+/doc/sphinx-bootstrap-theme
 /Testing
 /install_manifest.txt
+/breathe
 *~
 *.a
 *.so*


### PR DESCRIPTION
These are created when building the library and makes the directory dirty. This is annoying when using cppformat as a submodule since the submodule always will show up in the diff as dirty.

Personally I'd prefer to not modify the source directory at all when configuring and building. It should rather create files in the build directory, but I don't know if that is possible in this case.