### PR TITLE
Extend CI tests with older c++ standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
         6pxmyzLHSn1ZR7OX5rfPvwM3tOyZ3H0=
   matrix:
     - BUILD=Doc
-    - BUILD=Debug STANDARD=98
     - BUILD=Debug STANDARD=11
     - BUILD=Release STANDARD=98
+    - BUILD=Release STANDARD=03
     - BUILD=Release STANDARD=11
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+sudo: required # the doc target uses sudo to install dependencies
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ env:
         6pxmyzLHSn1ZR7OX5rfPvwM3tOyZ3H0=
   matrix:
     - BUILD=Doc
-    - BUILD=Debug
-    - BUILD=Release
+    - BUILD=Debug STANDARD=98
+    - BUILD=Debug STANDARD=11
+    - BUILD=Release STANDARD=98
+    - BUILD=Release STANDARD=11
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - BUILD=Doc
     - BUILD=Debug STANDARD=0x
     - BUILD=Release STANDARD=98
-    - BUILD=Release STANDARD=03
     - BUILD=Release STANDARD=0x
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ env:
         6pxmyzLHSn1ZR7OX5rfPvwM3tOyZ3H0=
   matrix:
     - BUILD=Doc
-    - BUILD=Debug STANDARD=11
+    - BUILD=Debug STANDARD=0x
     - BUILD=Release STANDARD=98
     - BUILD=Release STANDARD=03
-    - BUILD=Release STANDARD=11
+    - BUILD=Release STANDARD=0x
 
 matrix:
   exclude:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(FMT_PEDANTIC "Enable extra warnings and expensive tests." OFF)
 option(FMT_DOC "Generate the doc target." ${MASTER_PROJECT})
 option(FMT_INSTALL "Generate the install target." ${MASTER_PROJECT})
 option(FMT_TEST "Generate the test target." ${MASTER_PROJECT})
+option(FMT_USE_CPP11 "Enable the addition of c++11 compiler flags." ${MASTER_PROJECT})
 
 project(FORMAT)
 

--- a/cppformat/CMakeLists.txt
+++ b/cppformat/CMakeLists.txt
@@ -8,7 +8,9 @@ endif ()
 
 add_library(cppformat ${FMT_SOURCES} ${FMT_HEADERS})
 
-target_compile_options(cppformat PUBLIC ${CPP11_FLAG}) # starting with cmake 3.1 the CXX_STANDARD property can be used
+if (FMT_USE_CPP11)
+  target_compile_options(cppformat PUBLIC ${CPP11_FLAG}) # starting with cmake 3.1 the CXX_STANDARD property can be used
+endif ()
 if (FMT_PEDANTIC)
   target_compile_options(cppformat PRIVATE ${PEDANTIC_COMPILE_FLAGS})
 endif ()

--- a/cppformat/CMakeLists.txt
+++ b/cppformat/CMakeLists.txt
@@ -1,7 +1,6 @@
 #------------------------------------------------------------------------------
 # define the cppformat library, its includes and the needed defines
-set(FMT_HEADERS format.h)
-set(FMT_SOURCES format.cc)
+set(FMT_HEADERS format.h format.cc)
 if (HAVE_OPEN)
   set(FMT_HEADERS ${FMT_HEADERS} posix.h)
   set(FMT_SOURCES ${FMT_SOURCES} posix.cc)

--- a/support/cmake/testCxx11.cmake
+++ b/support/cmake/testCxx11.cmake
@@ -29,8 +29,10 @@ else ()
   endif ()
 endif ()
 
+if (FMT_USE_CPP11)
+  set(CMAKE_REQUIRED_FLAGS ${CPP11_FLAG})
+endif ()
 
-set(CMAKE_REQUIRED_FLAGS ${CPP11_FLAG})
 # Check if variadic templates are working and not affected by GCC bug 39653:
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=39653
 check_cxx_source_compiles("

--- a/support/travis-build.py
+++ b/support/travis-build.py
@@ -100,8 +100,6 @@ else:
                        '-DFMT_DOC=OFF',
                        '-DFMT_PEDANTIC=ON',
                        srcDir])
-else:
-
 
 # build library
 check_call(['make', '-j4'])

--- a/support/travis-build.py
+++ b/support/travis-build.py
@@ -12,6 +12,13 @@ def rmtree_if_exists(dir):
     if e.errno == errno.ENOENT:
       pass
 
+def makedirs_if_not_exist(dir):
+  try:
+    os.makedirs(dir)
+  except OSError as e:
+    if e.errno != errno.EEXIST:
+      raise
+
 build = os.environ['BUILD']
 if build == 'Doc':
   travis = 'TRAVIS' in os.environ
@@ -67,11 +74,57 @@ if build == 'Doc':
       raise CalledProcessError(p.returncode, cmd)
   exit(0)
 
-check_call(['git', 'submodule', 'update', '--init'])
-check_call(['cmake', '-DCMAKE_BUILD_TYPE=' + build, '-DFMT_PEDANTIC=ON', '.'])
+cppStandard = os.environ['STANDARD']
+srcDir = os.getcwd()
+srcDir_test = os.path.join(srcDir,"test","find-package-test")
+
+installDir    = os.path.join(srcDir,"_install")
+buildDir      = os.path.join(srcDir,"_build")
+buildDir_test = os.path.join(srcDir,"_build_test")
+
+# configure library
+makedirs_if_not_exist(buildDir)
+os.chdir(buildDir)
+if cppStandard == '98':
+  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
+                       '-DCMAKE_BUILD_TYPE=' + build,
+                       '-DCMAKE_CXX_FLAGS=-std=c++98',
+                       '-DFMT_USE_CPP11=OFF',
+                       '-DFMT_DOC=OFF',
+                       '-DFMT_PEDANTIC=ON',
+                       srcDir])
+else:
+  # default configuration
+  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
+                       '-DCMAKE_BUILD_TYPE=' + build,
+                       '-DFMT_DOC=OFF',
+                       '-DFMT_PEDANTIC=ON',
+                       srcDir])
+
+# build library
 check_call(['make', '-j4'])
+
+# test library
 env = os.environ.copy()
 env['CTEST_OUTPUT_ON_FAILURE'] = '1'
 if call(['make', 'test'], env=env):
   with open('Testing/Temporary/LastTest.log', 'r') as f:
     print(f.read())
+  sys.exit(-1)
+
+# install library
+check_call(['make', 'install'])
+
+# test installation
+makedirs_if_not_exist(buildDir_test)
+os.chdir(buildDir_test)
+if cppStandard == '98':
+  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
+                       '-DCMAKE_BUILD_TYPE=' + build,
+                       '-DCMAKE_CXX_FLAGS=-std=c++98',
+                       srcDir_test])
+else:
+  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
+                       '-DCMAKE_BUILD_TYPE=' + build,
+                       srcDir_test])
+check_call(['make', '-j4'])

--- a/support/travis-build.py
+++ b/support/travis-build.py
@@ -93,6 +93,14 @@ if cppStandard == '98':
                        '-DFMT_DOC=OFF',
                        '-DFMT_PEDANTIC=ON',
                        srcDir])
+if cppStandard == '03':
+  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
+                       '-DCMAKE_BUILD_TYPE=' + build,
+                       '-DCMAKE_CXX_FLAGS=-std=c++03',
+                       '-DFMT_USE_CPP11=OFF',
+                       '-DFMT_DOC=OFF',
+                       '-DFMT_PEDANTIC=ON',
+                       srcDir])
 else:
   # default configuration
   check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
@@ -118,13 +126,8 @@ check_call(['make', 'install'])
 # test installation
 makedirs_if_not_exist(buildDir_test)
 os.chdir(buildDir_test)
-if cppStandard == '98':
-  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
-                       '-DCMAKE_BUILD_TYPE=' + build,
-                       '-DCMAKE_CXX_FLAGS=-std=c++98',
-                       srcDir_test])
-else:
-  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
-                       '-DCMAKE_BUILD_TYPE=' + build,
-                       srcDir_test])
+check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
+                      '-DCMAKE_BUILD_TYPE=' + build,
+                      '-DCMAKE_CXX_FLAGS=-std=c++' + cppStandard,
+                      srcDir_test])
 check_call(['make', '-j4'])

--- a/support/travis-build.py
+++ b/support/travis-build.py
@@ -85,29 +85,23 @@ buildDir_test = os.path.join(srcDir,"_build_test")
 # configure library
 makedirs_if_not_exist(buildDir)
 os.chdir(buildDir)
-if cppStandard == '98':
-  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
-                       '-DCMAKE_BUILD_TYPE=' + build,
-                       '-DCMAKE_CXX_FLAGS=-std=c++98',
-                       '-DFMT_USE_CPP11=OFF',
-                       '-DFMT_DOC=OFF',
-                       '-DFMT_PEDANTIC=ON',
-                       srcDir])
-if cppStandard == '03':
-  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
-                       '-DCMAKE_BUILD_TYPE=' + build,
-                       '-DCMAKE_CXX_FLAGS=-std=c++03',
-                       '-DFMT_USE_CPP11=OFF',
-                       '-DFMT_DOC=OFF',
-                       '-DFMT_PEDANTIC=ON',
-                       srcDir])
-else:
+if cppStandard == '0x':
   # default configuration
   check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
                        '-DCMAKE_BUILD_TYPE=' + build,
                        '-DFMT_DOC=OFF',
                        '-DFMT_PEDANTIC=ON',
                        srcDir])
+else:
+  check_call(['cmake', '-DCMAKE_INSTALL_PREFIX='+installDir,
+                       '-DCMAKE_BUILD_TYPE=' + build,
+                       '-DCMAKE_CXX_FLAGS=-std=c++' + cppStandard,
+                       '-DFMT_USE_CPP11=OFF',
+                       '-DFMT_DOC=OFF',
+                       '-DFMT_PEDANTIC=ON',
+                       srcDir])
+else:
+
 
 # build library
 check_call(['make', '-j4'])

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,9 @@ add_library(gmock STATIC
   ${FMT_GMOCK_DIR}/gmock-gtest-all.cc ${FMT_GMOCK_DIR}/gmock/gmock.h
   ${FMT_GMOCK_DIR}/gtest/gtest.h ${FMT_GMOCK_DIR}/gtest/gtest-spi.h)
 target_include_directories(gmock PUBLIC ${FMT_GMOCK_DIR})
-target_compile_options(gmock PUBLIC ${CPP11_FLAG})
+if (FMT_USE_CPP11)
+  target_compile_options(gmock PUBLIC ${CPP11_FLAG})
+endif ()
 
 find_package(Threads)
 if (Threads_FOUND)
@@ -112,18 +114,6 @@ if (HAVE_FNO_EXCEPTIONS_FLAG)
 endif ()
 
 if (FMT_PEDANTIC)
-  # syntax test which checks if the library builds in gnu++98 mode
-  file(GLOB test_src *.cc *.h)
-  file(GLOB lib_src ../cppformat/*.cc ../cppformat/*.h)
-  add_library(testformat STATIC ${test_src} ${lib_src})
-  target_include_directories(testformat PRIVATE .. ../gmock)
-  target_compile_definitions(testformat PRIVATE
-    FMT_USE_FILE_DESCRIPTORS=$<BOOL:${HAVE_OPEN}>)
-  check_cxx_compiler_flag(-std=gnu++98 HAVE_STD_GNUPP98_FLAG)
-  if (HAVE_STD_GNUPP98_FLAG)
-    target_compile_options(testformat PRIVATE -std=gnu++98)
-  endif ()
-
   # Test that the library compiles without windows.h.
   if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_library(no-windows-h-test ../cppformat/format.cc)


### PR DESCRIPTION
Hi!
This PR increases the test coverage by building and testing the library in c++ 98, 03, and 0x mode with Travis. The older standards are only tested in release mode to reduce the number of builds.
