### PR TITLE
Fix switch fall-through warning

### DIFF
--- a/cppformat/format.cc
+++ b/cppformat/format.cc
@@ -676,6 +676,7 @@ FMT_FUNC Arg fmt::internal::FormatterBase::do_get_arg(
     break;
   case Arg::NAMED_ARG:
     arg = *static_cast<const internal::Arg*>(arg.pointer);
+    break;
   default:
     /*nothing*/;
   }


### PR DESCRIPTION
Clang with `-Wimplicit-fallthrough` enabled shows a warning here without
the break. See http://clang.llvm.org/docs/AttributeReference.html#fallthrough-clang-fallthrough